### PR TITLE
#46 implemented a way so that jwt token wouldn't be sent to the user

### DIFF
--- a/GamedevQuest/Controllers/LoginController.cs
+++ b/GamedevQuest/Controllers/LoginController.cs
@@ -3,6 +3,7 @@ using GamedevQuest.Models;
 using GamedevQuest.Models.DTO;
 using GamedevQuest.Services;
 using Microsoft.AspNetCore.Mvc;
+using static GamedevQuest.Helpers.AuthorizationHelper;
 
 namespace GamedevQuest.Controllers
 {
@@ -10,11 +11,11 @@ namespace GamedevQuest.Controllers
     [Route("api/[controller]")]
     public class LoginController : ControllerBase
     {
-        private readonly JwtTokenHelper _jwtTokenGenerator;
+        private readonly AuthorizationHelper _authorizationHelper;
         private readonly UserLoginService _userLoginService;
-        public LoginController(JwtTokenHelper jwtTokenGenerator, UserLoginService userLoginService)
+        public LoginController(AuthorizationHelper authorizationHelper, UserLoginService userLoginService)
         {
-            _jwtTokenGenerator = jwtTokenGenerator;
+            _authorizationHelper = authorizationHelper;
             _userLoginService = userLoginService;
         }
 
@@ -26,8 +27,8 @@ namespace GamedevQuest.Controllers
             OperationResult<User> result = await _userLoginService.ValidateUserLogin(request);
             if (result.Result == null)
                 return result.ActionResultObject;
-            string token = _jwtTokenGenerator.GenerateToken(result.Result.Email);
-            return Ok(new LoginResponseDto(result.Result, token));
+            _authorizationHelper.SavePlayerSession(result.Result.Email, Response);
+            return Ok(new LoginResponseDto(result.Result));
         }
     }
 }

--- a/GamedevQuest/Helpers/AuthorizationHelper.cs
+++ b/GamedevQuest/Helpers/AuthorizationHelper.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication.BearerToken;
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace GamedevQuest.Helpers
 {
@@ -19,7 +19,7 @@ namespace GamedevQuest.Helpers
                 Secure = true,
                 HttpOnly = true,
                 SameSite = SameSiteMode.Strict,
-                Expires = DateTime.UtcNow.AddMinutes(double.Parse(_jwtTokenHelper.Config["jwt:ExpireMinutes"]))
+                Expires = DateTime.UtcNow.AddMinutes(double.TryParse(_jwtTokenHelper.Config["jwt:ExpireMinutes"], out double minutes)?minutes:0)
             };
             response.Cookies.Append(AuthorizationKey, token, cookieOption);
         }

--- a/GamedevQuest/Helpers/AuthorizationHelper.cs
+++ b/GamedevQuest/Helpers/AuthorizationHelper.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Authentication.BearerToken;
+
+namespace GamedevQuest.Helpers
+{
+    public class AuthorizationHelper
+    {
+        private readonly JwtTokenHelper _jwtTokenHelper;
+        public static readonly string AuthorizationKey = "jwt_token";
+        public AuthorizationHelper(JwtTokenHelper jwtTokenHelper)
+        {
+            _jwtTokenHelper = jwtTokenHelper;
+        }
+
+        public void SavePlayerSession(string email, HttpResponse response)
+        {
+            string token = _jwtTokenHelper.GenerateToken(email);
+            var cookieOption = new CookieOptions
+            {
+                Secure = true,
+                HttpOnly = true,
+                SameSite = SameSiteMode.Strict,
+                Expires = DateTime.UtcNow.AddMinutes(double.Parse(_jwtTokenHelper.Config["jwt:ExpireMinutes"]))
+            };
+            response.Cookies.Append(AuthorizationKey, token, cookieOption);
+        }
+
+        public Task AuthorizeCookies(MessageReceivedContext context)
+        {
+            if (context.Request.Cookies.ContainsKey(AuthorizationKey))
+            {
+                context.Token = context.Request.Cookies[AuthorizationKey];
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/GamedevQuest/Helpers/DependencyInjectionHelper.cs
+++ b/GamedevQuest/Helpers/DependencyInjectionHelper.cs
@@ -22,6 +22,7 @@ namespace GamedevQuest.Helpers
             _builder.Services.AddScoped<LessonService>();
             _builder.Services.AddScoped<TestService>();
             _builder.Services.AddScoped<JwtTokenHelper>();
+            _builder.Services.AddScoped<AuthorizationHelper>();
             _builder.Services.AddScoped<PasswordHelper>();
             _builder.Services.AddScoped<UserService>();
         }

--- a/GamedevQuest/Helpers/JwtTokenHelper.cs
+++ b/GamedevQuest/Helpers/JwtTokenHelper.cs
@@ -7,11 +7,11 @@ namespace GamedevQuest.Helpers
 {
     public class JwtTokenHelper
     {
-        private IConfiguration _config;
+        public IConfiguration Config { get; private set; }
 
         public JwtTokenHelper(IConfiguration config)
         {
-            _config = config;
+            Config = config;
         }
         public string GenerateToken(string email)
         {
@@ -19,16 +19,16 @@ namespace GamedevQuest.Helpers
             {
                 new Claim(ClaimTypes.Name, email)
             };
-            Console.Write(_config["jwt:Key"]);
-            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["jwt:Key"]));
+            Console.Write(Config["jwt:Key"]);
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Config["jwt:Key"]));
             var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
             var token = new JwtSecurityToken
             (
-                issuer: _config["jwt:Issuer"],
-                audience: _config["jwt:Audience"],
+                issuer: Config["jwt:Issuer"],
+                audience: Config["jwt:Audience"],
                 claims: claims,
-                expires: DateTime.Now.AddMinutes(double.Parse(_config["jwt:ExpireMinutes"])),
+                expires: DateTime.Now.AddMinutes(double.Parse(Config["jwt:ExpireMinutes"])),
                 signingCredentials: credentials
             );
             return new JwtSecurityTokenHandler().WriteToken(token);

--- a/GamedevQuest/Helpers/JwtTokenHelper.cs
+++ b/GamedevQuest/Helpers/JwtTokenHelper.cs
@@ -19,7 +19,6 @@ namespace GamedevQuest.Helpers
             {
                 new Claim(ClaimTypes.Name, email)
             };
-            Console.Write(Config["jwt:Key"]);
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Config["jwt:Key"]));
             var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 

--- a/GamedevQuest/Models/DTO/LoginDTO.cs
+++ b/GamedevQuest/Models/DTO/LoginDTO.cs
@@ -12,19 +12,17 @@ namespace GamedevQuest.Models.DTO
     public class LoginResponseDto
     {
         public int Id { get; set; }
-        public string Token { get; set; }
         public string Username { get; set; }
         public string Email { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
-        public LoginResponseDto(User user, string token)
+        public LoginResponseDto(User user)
         {
             Id = user.Id;
             Username = user.Username;
             Email = user.Email;
             FirstName = user.FirstName;
             LastName = user.LastName;
-            Token = token;
         }
     }
 }

--- a/GamedevQuest/Models/Lesson.cs
+++ b/GamedevQuest/Models/Lesson.cs
@@ -9,7 +9,7 @@
         public int Xp { get; private set; }
         public List<int> RelatedTests { get; private set; }
         public string LessonImageUrl { get; private set; }
-        public Lesson(int id, string lessonTitle, string lessonDescription, int minimumRequiredLevel, int xp, List<int> relatedTests, string lessonImageUrl, List<string> tags)
+        public Lesson(int id, string lessonTitle, string lessonDescription, int minimumRequiredLevel, int xp, List<int> relatedTests, string lessonImageUrl)
         {
             Id = id;
             LessonTitle = lessonTitle;

--- a/GamedevQuest/Program.cs
+++ b/GamedevQuest/Program.cs
@@ -1,6 +1,7 @@
 ﻿using GamedevQuest.Context;
 using GamedevQuest.Helpers;
 using GamedevQuest.Helpers.DatabaseHelpers;
+using Microsoft.AspNetCore.Authentication.BearerToken;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
@@ -34,7 +35,18 @@ builder.Services.AddAuthentication("Bearer")
             ValidAudience = jwtConfig["Audience"],
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtConfig["Key"]))
         };
+        options.Events = new Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents
+        {
+            OnMessageReceived = context => {
+                if (context.Request.Cookies.ContainsKey(AuthorizationHelper.AuthorizationKey))
+                {
+                    context.Token = context.Request.Cookies[AuthorizationHelper.AuthorizationKey];
+                }
+                return Task.CompletedTask;
+            }
+        };
     });
+
 
 builder.Services.AddAuthorization();
 


### PR DESCRIPTION
I used http only cookies for safer storage of jwt tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Login now creates a secure, HttpOnly cookie-based session for authentication.
  - Automatic authentication from cookies; no manual token handling required.

- Refactor
  - Login response no longer returns an access token; it returns only user data.
  - Lesson payload no longer includes tags (adjust client integrations).

- Chores
  - Dependency setup updated to support cookie-based sessions.

- Tests
  - Verify login, session persistence, and authenticated requests via cookies across browsers and sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->